### PR TITLE
docs: add example to get available cameras (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ info {
 
 The behavior of the service can be customized by passing a JSON configuration file as the first argument, e.g: `is-broker-events etc/conf/options.json`. The schema for this file can be found in [`is_broker_events/conf/options.proto`](https://github.com/labvisio/is-broker-events/blob/master/is_broker_events/conf/options.proto). An example configuration file can be found in [`etc/conf/options.json`](https://github.com/labvisio/is-broker-events/blob/master/etc/conf/options.json).
 
+## Examples
+
+In the [examples](https://github.com/labvisio/is-broker-events/blob/master/examples) directory, you can find a series of examples that may be useful to you. The examples available are:
+
+* [`get_available_cameras.py`](https://github.com/labvisio/is-broker-events/blob/master/examples/get_available_cameras.py): Script to find online cameras in the IS, it subscribes to receive the consumer list from this service and filter topics that match the RPC configuration topic provided by the cameras services, such as [is-spinnaker-gateway](https://github.com/labvisio/is-spinnaker-gateway).
+
 ## RabbitMQ Event Exchange
 
 The broker is deployed using a plugin known as the [RabbitMQ Event Exchange](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_event_exchange). This plugin serves as an interface to the internal event system of RabbitMQ, allowing clients to consume these events as messages. It's useful when you need to monitor specific events, such as the creation and deletion of queues, exchanges, bindings, users, connections, and channels.

--- a/examples/get_available_cameras.py
+++ b/examples/get_available_cameras.py
@@ -1,0 +1,29 @@
+import json
+import re
+import socket
+
+from is_msgs.common_pb2 import ConsumerList
+from is_wire.core import Subscription, Channel
+
+RE_CAMERA_GATEWAY_CONSUMER = re.compile("CameraGateway\\.(\\d+)\\.GetConfig")
+
+if __name__ == "__main__":
+
+    broker_uri = json.load(open("../etc/conf/options.json"))["broker_uri"]
+    channel = Channel(broker_uri)
+    subscription = Subscription(channel)
+    subscription.subscribe("BrokerEvents.Consumers")
+    available_cameras = []
+    try:
+        message = channel.consume(timeout=5)
+        consumers = message.unpack(ConsumerList)
+        for key, _ in consumers.info.items():
+            match = RE_CAMERA_GATEWAY_CONSUMER.match(key)
+            if match is None:
+                continue
+            available_cameras.append(int(match.group(1)))
+
+        print(f'Available Cameras {available_cameras}')
+    except socket.timeout:
+        print('No reply :(')
+   

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ deps =
   pytest-cov
 
 [testenv:flake8]
-commands = flake8 is_broker_events
+commands = flake8 is_broker_events examples
 deps = 
   flake8
 


### PR DESCRIPTION
* docs: add new example

* fix: organize examples

* rename to examples, because it may include more examples in the future
* simplify example script
* subscription_manager doesnt makes much sense to example, rename to get_available_cameras

* docs: add section about examples in README

* fix: update setup.cfg to new folder

---------